### PR TITLE
Fix quotation marks in PrismicScript source

### DIFF
--- a/components/PrismicScript.js
+++ b/components/PrismicScript.js
@@ -1,9 +1,13 @@
 import { apiEndpoint } from 'prismic-configuration'
 
 const PrismicScript = () => {
-  const [, repoName] = apiEndpoint.match(/https?:\/\/([^.]+)?\.(cdn\.)?.+/);
+  const [, repoName] = apiEndpoint.match(/https?:\/\/([^.]+)?\.(cdn\.)?.+/)
   return (
-    <script async defer src={`"https://static.cdn.prismic.io/prismic.min.js?repo=${repoName}&new=true"`} />
+    <script
+      async
+      defer
+      src={`https://static.cdn.prismic.io/prismic.min.js?repo=${repoName}&new=true`}
+    />
   )
 }
 


### PR DESCRIPTION
This fixes extra quotation marks in `PrismicScript.js`, which create a 404.

Fixes #22